### PR TITLE
Update .NET Core example to use latest version of runtime

### DIFF
--- a/dotnet-core/.gitignore
+++ b/dotnet-core/.gitignore
@@ -1,0 +1,5 @@
+.vscode
+appsettings.Development.json
+appsettings.json
+[Bb]in/
+[Oo]bj/

--- a/dotnet-core/Program.cs
+++ b/dotnet-core/Program.cs
@@ -1,26 +1,20 @@
-using System.IO;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
-namespace HelloWeb
+namespace dot_net_gov
 {
     public class Program
     {
         public static void Main(string[] args)
         {
-
-            var config = new ConfigurationBuilder()
-                          .AddCommandLine(args)
-                          .Build();
-            var host = new WebHostBuilder()
-                        .UseKestrel()
-                        .UseConfiguration(config)
-                        .UseContentRoot(Directory.GetCurrentDirectory())
-                        .UseIISIntegration()
-                        .UseStartup<Startup>()
-                        .Build();
-
-            host.Run();
+            CreateHostBuilder(args).Build().Run();
         }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/dotnet-core/Startup.cs
+++ b/dotnet-core/Startup.cs
@@ -1,17 +1,35 @@
-// Modified 2017 Peter Burkholder, cloud.gov
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
-namespace HelloWeb
+namespace dot_net_gov
 {
     public class Startup
     {
-        public void Configure(IApplicationBuilder app)
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
         {
-            app.Run(context =>
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
             {
-                return context.Response.WriteAsync("Hello World from .Net Core 2!");
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync("Hello World from .Net Core 3.1!");
+                });
             });
         }
     }

--- a/dotnet-core/dotnet-core-hello-world.csproj
+++ b/dotnet-core/dotnet-core-hello-world.csproj
@@ -1,15 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <DebugType>portable</DebugType>
-    <AssemblyName>dotnet-core-hello-world</AssemblyName>
-    <OutputType>Exe</OutputType>
-    <PackageId>dotnet-core-hello-world</PackageId>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>dot_net_gov</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.1.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.*" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updated sample to use [latest version](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) of .NET runtime
- Modified structure of app files to mirror files auto created via `dotnet new web`
- Add `.gitignore` file to ignore any .NET artifacts generated locally

## security considerations
- None

