### PR TITLE
Update nodejs to the default version in buildpack v1.7.54

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "node-example",
   "version": "0.0.1",
   "engines": {
-    "node": "10.x",
+    "node": "14.x",
     "npm": "6.x"
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update to 14.x
  - See https://github.com/cloudfoundry/nodejs-buildpack/releases/tag/v1.7.54
  - Node v10 removed in https://github.com/cloudfoundry/nodejs-buildpack/releases/tag/v1.7.53
- Fixes buildpack smoke test 


## security considerations
none
