### PR TITLE
Up min nodejs since 14.x was deprecated

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "node-example",
   "version": "0.0.1",
   "engines": {
-    "node": "14.x",
+    "node": "18.x",
     "npm": "6.x"
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move sample nodejs min version from `14.x` to `18.x` since `14.x` was deprecated in node-js builpack

## security considerations
Having current hello-world apps deploying on a regular basis helps flush out platorm buildpack issues
