### PR TITLE
Patch for new version of Werkzeug

### DIFF
--- a/python-flask/requirements.txt
+++ b/python-flask/requirements.txt
@@ -1,1 +1,2 @@
 Flask==2.0.2
+Werkzeug==2.2.2


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fix for python-flask with error:

```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/home/vcap/deps/0/python/lib/python3.10/site-packages/werkzeug/urls.py)
```

## security considerations
None
