### PR TITLE
use general-task image and install jdk

### DIFF
--- a/java-see/build-java-see.sh
+++ b/java-see/build-java-see.sh
@@ -4,6 +4,15 @@ set -ex
 
 export TERM=${TERM:-dumb}
 
+wget https://download.oracle.com/java/22/latest/jdk-22_linux-x64_bin.tar.gz
+tar -xvf jdk-22_linux-x64_bin.tar.gz
+mv jdk-22.0.1 /opt/
+
+JAVA_HOME='/opt/jdk-22.0.1'
+export JAVA_HOME
+PATH="JAVA_HOME/bin:$PATH"
+export PATH
+
 pushd cf-hello-worlds/java-see
   ./mvnw compile
   ./mvnw package

--- a/java-see/build-java-see.yml
+++ b/java-see/build-java-see.yml
@@ -2,9 +2,13 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: adoptopenjdk/openjdk11
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 inputs:
 - name: cf-hello-worlds


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use general-task image with jdk installed for building java app

## security considerations
Switch to using hardened image
