### PR TITLE
Allstar - Add binary artifacts ignore paths

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,4 @@
+# Ignore reason: These files are used for the Maven wrapper, which is useful
+ignorePaths:
+- java-see/.mvn/wrapper/maven-wrapper.jar
+- java-spring-actuator/.mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
## Changes proposed in this pull request:

- add configuration to ignore maven wrapper files for Allstar binary artifacts policy

## security considerations

We are excluding the configured files from Allstar's binary artifacts check since they are trusted Maven files
