### PR TITLE
Upgrade dotnet app to use 8.0

### DIFF
--- a/dotnet-core/Startup.cs
+++ b/dotnet-core/Startup.cs
@@ -28,7 +28,7 @@ namespace dot_net_gov
             {
                 endpoints.MapGet("/", async context =>
                 {
-                    await context.Response.WriteAsync("Hello World from .Net Core 6.0!");
+                    await context.Response.WriteAsync("Hello World from .Net Core 8.0!");
                 });
             });
         }

--- a/dotnet-core/dotnet-core-hello-world.csproj
+++ b/dotnet-core/dotnet-core-hello-world.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>netcoreapp8.0</TargetFramework>
     <RootNamespace>dot_net_gov</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- https://github.com/cloudfoundry/dotnet-core-buildpack/releases/tag/v2.4.36 no longer supports 6.0
- Part of general platform maintenance: https://github.com/cloud-gov/private/issues/618
-

## security considerations
Bump codebase to supported version required by the buildpack
