### PR TITLE
Remove dependencies check from py-flask

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -15,8 +15,6 @@ jobs:
             passed: [set-self]
           - get: timer
             trigger: true
-      - task: update-dependencies
-        file: cf-hello-worlds/python-flask/check-dependencies.yml
       - put: deploy-python-flask-staging
         params:
           config:


### PR DESCRIPTION
## Changes proposed in this pull request:
-
From @cweibel 

> There is a concourse pipeline for deploy-python-flask which [is failing with](https://ci.fr.cloud.gov/teams/main/pipelines/test-hello-worlds/jobs/deploy-python-flask/builds/3008):
 task config ‘cf-hello-worlds/python-flask/check-dependencies.yml’ not found
I can see that you removed check-dependencies.yml with https://github.com/cloud-gov/cf-hello-worlds/commit/37d70adf360c9c49613375f838a305be54da4135
Can you take a look and figure out a resolution?
-

## security considerations
Safe. Removed dependency on already deleted file.
