### PR TITLE
Change to url for docker.io

### DIFF
--- a/nodejs/manifest-cnb.yml
+++ b/nodejs/manifest-cnb.yml
@@ -4,7 +4,7 @@ applications:
   random-route: true
   lifecycle: cnb
   buildpacks:
-  - docker://docker.io/paketo-buildpacks/nodejs
+  - docker://docker.io/paketobuildpacks/nodejs
   memory: 256M
   stack: cflinuxfs4
   env:


### PR DESCRIPTION
## Changes proposed in this pull request:

- update node cnb buildpack reference URL to use docker.io to fix failing deploy

## security considerations

None, just fixing deployment failure
