### PR TITLE
remove unneeded general-task code

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -17,25 +17,10 @@ jobs:
             trigger: true
       - put: deploy-python-flask-staging
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: &general-task
-              aws_access_key_id: ((ecr_aws_key))
-              aws_secret_access_key: ((ecr_aws_secret))
-              repository: general-task
-              aws_region: us-gov-west-1
-              tag: latest
           path: cf-hello-worlds/python-flask
           manifest: cf-hello-worlds/python-flask/manifest.yml
       - put: deploy-python-flask-production
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/python-flask
           manifest: cf-hello-worlds/python-flask/manifest.yml
     on_failure:
@@ -54,20 +39,10 @@ jobs:
       - in_parallel: *plan-gets
       - put: deploy-ruby-sinatra-staging
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/ruby-sinatra
           manifest: cf-hello-worlds/ruby-sinatra/manifest.yml
       - put: deploy-ruby-sinatra-production
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/ruby-sinatra
           manifest: cf-hello-worlds/ruby-sinatra/manifest.yml
     on_failure:
@@ -84,20 +59,10 @@ jobs:
       - in_parallel: *plan-gets
       - put: deploy-nodejs-staging
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/nodejs
           manifest: cf-hello-worlds/nodejs/manifest.yml
       - put: deploy-nodejs-production
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/nodejs
           manifest: cf-hello-worlds/nodejs/manifest.yml
     on_failure:
@@ -114,20 +79,10 @@ jobs:
       - in_parallel: *plan-gets
       - put: deploy-nodejs-cnb-staging
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/nodejs
           manifest: cf-hello-worlds/nodejs/manifest-cnb.yml
       - put: deploy-nodejs-cnb-production
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/nodejs
           manifest: cf-hello-worlds/nodejs/manifest-cnb.yml
     on_failure:
@@ -144,20 +99,10 @@ jobs:
       - in_parallel: *plan-gets
       - put: deploy-php-staging
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/php
           manifest: cf-hello-worlds/php/manifest.yml
       - put: deploy-php-production
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/php
           manifest: cf-hello-worlds/php/manifest.yml
     on_failure:
@@ -176,20 +121,10 @@ jobs:
         file: cf-hello-worlds/java-see/build-java-see.yml
       - put: deploy-java-staging
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds-build/java-see/target/hello-world-0.0.1-SNAPSHOT.jar
           manifest: cf-hello-worlds-build/java-see/manifest.yml
       - put: deploy-java-production
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds-build/java-see/target/hello-world-0.0.1-SNAPSHOT.jar
           manifest: cf-hello-worlds-build/java-see/manifest.yml
     on_failure:
@@ -206,20 +141,10 @@ jobs:
       - in_parallel: *plan-gets
       - put: deploy-dotnet-core-staging
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/dotnet-core
           manifest: cf-hello-worlds/dotnet-core/manifest.yml
       - put: deploy-dotnet-core-production
         params:
-          config:
-            platform: linux
-          image_resource:
-            type: registry-image
-            source: *general-task
           path: cf-hello-worlds/dotnet-core
           manifest: cf-hello-worlds/dotnet-core/manifest.yml
     on_failure:


### PR DESCRIPTION
## Changes proposed in this pull request:
- This removes the references to general-task under params for each of the put tasks
- It isn't actually used anywhere, and if we were trying to specify the general-task image to be used, it would not be under the params but under config

## security considerations
Removing unneeded code